### PR TITLE
Make PVC accessMode configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ after_success:
 - codecov
 - |-
   test ${TRAVIS_PYTHON_VERSION} = 3.8 &&
+  test -n "${DOCKER_PASSWORD}" &&
   echo '{"mtu": 1460}' | sudo dd of=/etc/docker/daemon.json &&
   sudo systemctl restart docker &&
   docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" &&

--- a/docs/user_guide/change_log.rst
+++ b/docs/user_guide/change_log.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+0.5.2
+-----
+
+ngshare:
+
+- Update helm chart to allow configuring the `accessMode` of ngshare's PVC via `pvc.accessModes`. The PVC will be mounted `ReadWriteMany` by default unless you override this value. (Thanks [pcfens](https://github.com/pcfens) for the [PR](https://github.com/LibreTexts/ngshare/pull/120)!)
+
 0.5.1
 -----
 

--- a/helmchart/ngshare/templates/pvc.yaml
+++ b/helmchart/ngshare/templates/pvc.yaml
@@ -17,11 +17,7 @@ spec:
   storageClassName: {{ .Values.pvc.storageClassName | quote }}
   {{- end }}
   accessModes:
-    {{- if gt .Values.deployment.replicaCount 1.0 }}
-    - ReadWriteOnce
-    {{- else }}
-    - ReadWriteMany
-    {{- end }}
+    {{- .Values.pvc.accessModes | toYaml | trimSuffix "\n" | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.pvc.storage | quote }}

--- a/helmchart/ngshare/values.yaml
+++ b/helmchart/ngshare/values.yaml
@@ -80,3 +80,5 @@ pvc:
   annotations: {}
   selector: {}
   storageClassName: ""
+  accessModes:
+  - ReadWriteMany


### PR DESCRIPTION
Rather than making the PV accessMode defined by the replica count this allows users to set it directly. Tieing the accessMode to
replicaCounts make it difficult for users to make changes in the future without also forcing an accessMode change, which can be disruptive.

The previous logic set it so that a PVs were provisioned with ReadWriteMany when defaults are used, this retains that behavior.