### PR TITLE
Fix Travis untrusted builds failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ after_success:
 - codecov
 - |-
   test ${TRAVIS_PYTHON_VERSION} = 3.8 &&
+  test -n "${DOCKER_PASSWORD}" &&
   echo '{"mtu": 1460}' | sudo dd of=/etc/docker/daemon.json &&
   sudo systemctl restart docker &&
   docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" &&


### PR DESCRIPTION
Currently untrusted builds (builds initiated by for example PRs from users who don't have write access to this repo) are failing since they don't have access to encrypted environment variables to push to Docker Hub (see [this](https://travis-ci.org/github/LibreTexts/ngshare/jobs/712640792#L464)). This adds a check so if it's an untrusted build, we don't try to push the image to Docker Hub or the helm repo.