### PR TITLE
Make Travis CI jobs fail fast if the code is not formatted well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ install:
 before_script:
 - python3 -m pip install -r testing_reqs.txt
 script:
-- python3 -m pytest ./ngshare/ --cov=./ngshare/
 - python3 -m black -S -l 80 --check .
 - helm2 lint --strict helmchart/ngshare
 - helm lint --strict helmchart/ngshare
+- python3 -m pytest ./ngshare/ --cov=./ngshare/
 after_success:
 - codecov
 - |-


### PR DESCRIPTION
This makes sure the developers do not wait for pytest to finish successfully and then fail on black. 