### PR TITLE
Allow initContainers in deployment

### DIFF
--- a/docs/user_guide/change_log.rst
+++ b/docs/user_guide/change_log.rst
@@ -7,6 +7,7 @@ Change Log
 ngshare:
 
 - Update helm chart to allow configuring the `accessMode` of ngshare's PVC via `pvc.accessModes`. The PVC will be mounted `ReadWriteMany` by default unless you override this value. (Thanks [pcfens](https://github.com/pcfens) for the [PR](https://github.com/LibreTexts/ngshare/pull/120)!)
+- Update helm chart to allow `initContainers` to be added, via `deployment.initContainers`. This is an array of `initContainers`, such as expected in Kubernetes, and such as implemented in Z2JH itself.
 
 0.5.1
 -----

--- a/helmchart/ngshare/templates/deployment.yaml
+++ b/helmchart/ngshare/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       securityContext:
         runAsNonRoot: true
         fsGroup: {{ .Values.deployment.fsGroup }}
+      {{- if .Values.deployment.initContainers }}
+      initContainers:
+        {{- .Values.deployment.initContainers | toYaml | trimSuffix "\n" | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helmchart/ngshare/values.yaml
+++ b/helmchart/ngshare/values.yaml
@@ -37,6 +37,8 @@ deployment:
   tolerations: []
   affinity: {}
 
+  initContainers: []
+
 
 # Configure environment / cmdline passed to ngshare
 ngshare:


### PR DESCRIPTION
PVC provisioners do not always spawn a volume with open permissions.
Init containers allow to chown the volume before ngshare is started, and allow many other initializations.

This copies the initContainers idea that is used in z2jh.