### PR TITLE
Expose deployment strategy

### DIFF
--- a/docs/user_guide/change_log.rst
+++ b/docs/user_guide/change_log.rst
@@ -8,6 +8,7 @@ ngshare:
 
 - Update helm chart to allow configuring the `accessMode` of ngshare's PVC via `pvc.accessModes`. The PVC will be mounted `ReadWriteMany` by default unless you override this value. (Thanks [pcfens](https://github.com/pcfens) for the [PR](https://github.com/LibreTexts/ngshare/pull/120)!)
 - Update helm chart to allow `initContainers` to be added, via `deployment.initContainers`. This is an array of `initContainers`, such as expected in Kubernetes, and such as implemented in Z2JH itself.
+- Update helm chart to allow `strategy` to be specified, via `deployment.strategy`. This is an object passed to the Deployment's `strategy`, as specified in the Kubernetes documentation at https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy.
 
 0.5.1
 -----

--- a/helmchart/ngshare/templates/deployment.yaml
+++ b/helmchart/ngshare/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "ngshare.selectorLabels" . | nindent 6 }}
+  strategy: {{ .Values.deployment.strategy }}
   template:
     metadata:
       labels:

--- a/helmchart/ngshare/values.yaml
+++ b/helmchart/ngshare/values.yaml
@@ -15,6 +15,9 @@ deployment:
   # WARNING: Anything greater than 1 is not tested
   replicaCount: 1
 
+  # Strategy for redeployment https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy: {}
+
   # Port to expose on the ClusterIP service. Shouldn't matter that much.
   port: 8080
 


### PR DESCRIPTION
The data on the `PVC` is not ought to be shared between multiple spawned pods; this may lead to race conditions, and is even impossible when the data is on a `ReadWriteOnce` specced volume.

This patch allows to specify the Deployment's `strategy`, as to tell Kubernetes not to have a rolling update when these kind of volumes are used.

I have not changed the default value, although it would be advisable to put the strategy on `Recreate` for the default settings, since the default settings introduce race conditions.

```yaml
deployment:
  strategy:
    type: Recreate # Default would be RollingUpdate
```