### PR TITLE
Fix chartpress failing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ after_success:
   openssl aes-256-cbc -K $encrypted_defe1004a0ce_key -iv $encrypted_defe1004a0ce_iv -in helmchart/ssh_key.enc -out /tmp/ssh_key -d &&
   chmod 400 /tmp/ssh_key &&
   python3 -m pip install chartpress docker==4.2.1 &&
+  cd helmchart &&
   GIT_SSH_COMMAND="ssh -i /tmp/ssh_key" chartpress --push --publish-chart --long &&
   test -n "${TRAVIS_TAG}" &&
   GIT_SSH_COMMAND="ssh -i /tmp/ssh_key" chartpress --push --publish-chart --tag "${TRAVIS_TAG}"

--- a/helmchart/chartpress.yaml
+++ b/helmchart/chartpress.yaml
@@ -1,5 +1,5 @@
 charts:
-  - name: helmchart/ngshare
+  - name: ngshare
     imagePrefix: libretexts/
     repo:
       git: libretexts/ngshare-helm-repo

--- a/helmchart/chartpress.yaml
+++ b/helmchart/chartpress.yaml
@@ -6,6 +6,6 @@ charts:
       published: https://libretexts.github.io/ngshare-helm-repo
     images:
       ngshare:
-        dockerfilePath: Dockerfile
+        dockerfilePath: ../Dockerfile
         contextPath: ..
         valuesPath: image

--- a/helmchart/chartpress.yaml
+++ b/helmchart/chartpress.yaml
@@ -7,5 +7,5 @@ charts:
     images:
       ngshare:
         dockerfilePath: Dockerfile
-        contextPath: .
+        contextPath: ..
         valuesPath: image

--- a/ngshare/alembic/versions/aa00db20c10a_init.py
+++ b/ngshare/alembic/versions/aa00db20c10a_init.py
@@ -44,7 +44,10 @@ def upgrade():
         sa.Column('id', sa.TEXT(), nullable=True),
         sa.Column('course_id', sa.INTEGER(), nullable=True),
         sa.Column('due', sa.TIMESTAMP(), nullable=True),
-        sa.ForeignKeyConstraint(['course_id'], ['courses._id'],),
+        sa.ForeignKeyConstraint(
+            ['course_id'],
+            ['courses._id'],
+        ),
         sa.PrimaryKeyConstraint('_id'),
     )
     op.create_table(
@@ -54,8 +57,14 @@ def upgrade():
         sa.Column('first_name', sa.TEXT(), nullable=True),
         sa.Column('last_name', sa.TEXT(), nullable=True),
         sa.Column('email', sa.TEXT(), nullable=True),
-        sa.ForeignKeyConstraint(['left_id'], ['users.id'],),
-        sa.ForeignKeyConstraint(['right_id'], ['courses.id'],),
+        sa.ForeignKeyConstraint(
+            ['left_id'],
+            ['users.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['right_id'],
+            ['courses.id'],
+        ),
         sa.PrimaryKeyConstraint('left_id', 'right_id'),
     )
     op.create_table(
@@ -65,16 +74,28 @@ def upgrade():
         sa.Column('first_name', sa.TEXT(), nullable=True),
         sa.Column('last_name', sa.TEXT(), nullable=True),
         sa.Column('email', sa.TEXT(), nullable=True),
-        sa.ForeignKeyConstraint(['left_id'], ['users.id'],),
-        sa.ForeignKeyConstraint(['right_id'], ['courses.id'],),
+        sa.ForeignKeyConstraint(
+            ['left_id'],
+            ['users.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['right_id'],
+            ['courses.id'],
+        ),
         sa.PrimaryKeyConstraint('left_id', 'right_id'),
     )
     op.create_table(
         'assignment_files_assoc_table',
         sa.Column('left_id', sa.TEXT(), nullable=False),
         sa.Column('right_id', sa.INTEGER(), nullable=False),
-        sa.ForeignKeyConstraint(['left_id'], ['assignments._id'],),
-        sa.ForeignKeyConstraint(['right_id'], ['files._id'],),
+        sa.ForeignKeyConstraint(
+            ['left_id'],
+            ['assignments._id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['right_id'],
+            ['files._id'],
+        ),
         sa.PrimaryKeyConstraint('left_id', 'right_id'),
     )
     op.create_table(
@@ -83,24 +104,42 @@ def upgrade():
         sa.Column('assignment_id', sa.INTEGER(), nullable=True),
         sa.Column('timestamp', sa.TIMESTAMP(), nullable=True),
         sa.Column('student_id', sa.TEXT(), nullable=True),
-        sa.ForeignKeyConstraint(['assignment_id'], ['assignments._id'],),
-        sa.ForeignKeyConstraint(['student_id'], ['users.id'],),
+        sa.ForeignKeyConstraint(
+            ['assignment_id'],
+            ['assignments._id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['student_id'],
+            ['users.id'],
+        ),
         sa.PrimaryKeyConstraint('_id'),
     )
     op.create_table(
         'feedback_files_assoc_table',
         sa.Column('left_id', sa.TEXT(), nullable=False),
         sa.Column('right_id', sa.INTEGER(), nullable=False),
-        sa.ForeignKeyConstraint(['left_id'], ['submissions._id'],),
-        sa.ForeignKeyConstraint(['right_id'], ['files._id'],),
+        sa.ForeignKeyConstraint(
+            ['left_id'],
+            ['submissions._id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['right_id'],
+            ['files._id'],
+        ),
         sa.PrimaryKeyConstraint('left_id', 'right_id'),
     )
     op.create_table(
         'submission_files_assoc_table',
         sa.Column('left_id', sa.TEXT(), nullable=False),
         sa.Column('right_id', sa.INTEGER(), nullable=False),
-        sa.ForeignKeyConstraint(['left_id'], ['submissions._id'],),
-        sa.ForeignKeyConstraint(['right_id'], ['files._id'],),
+        sa.ForeignKeyConstraint(
+            ['left_id'],
+            ['submissions._id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['right_id'],
+            ['files._id'],
+        ),
         sa.PrimaryKeyConstraint('left_id', 'right_id'),
     )
     # ### end Alembic commands ###

--- a/ngshare/database/database.py
+++ b/ngshare/database/database.py
@@ -100,13 +100,17 @@ class Course(Base):
     instructors = association_proxy(
         'inst_assoc',
         'user',
-        creator=lambda user: InstructorAssociation(user=user,),
+        creator=lambda user: InstructorAssociation(
+            user=user,
+        ),
         cascade_scalar_deletes=True,
     )
     students = association_proxy(
         'student_assoc',
         'user',
-        creator=lambda user: StudentAssociation(user=user,),
+        creator=lambda user: StudentAssociation(
+            user=user,
+        ),
         cascade_scalar_deletes=True,
     )
     assignments = relationship('Assignment', backref='course')

--- a/ngshare/database/test_database.py
+++ b/ngshare/database/test_database.py
@@ -38,17 +38,17 @@ def clear_db(db, storage_path):
 
 
 def init_db(db, storage_path):
-    '''
-        Create testing data
-        course1
-            instructor = [kevin]
-            student = [lawrence]
-            assignments = [challenge] (two submissions, one feedback)
-        course2
-            instructor = [abigail]
-            student = [eric]
-            assignments = [assignment2a, assignment2b] (no submissions)
-    '''
+    """
+    Create testing data
+    course1
+        instructor = [kevin]
+        student = [lawrence]
+        assignments = [challenge] (two submissions, one feedback)
+    course2
+        instructor = [abigail]
+        student = [eric]
+        assignments = [assignment2a, assignment2b] (no submissions)
+    """
     uk = User('kevin')
     ua = User('abigail')
     ul = User('lawrence')
@@ -105,7 +105,10 @@ def dump_db(db):
     ):
         for i in db.query(table).all():
             ans[table.name].append(
-                {'left_id': i.left_id, 'right_id': i.right_id,}
+                {
+                    'left_id': i.left_id,
+                    'right_id': i.right_id,
+                }
             )
     return ans
 

--- a/ngshare/ngshare.py
+++ b/ngshare/ngshare.py
@@ -85,17 +85,17 @@ class MyHelpers:
                 self.json_error(400, 'Time format incorrect')
 
     def path_check(self, pathname):
-        '''
-            Return whether a pathname (for file, in director tree) is safe
-            Current policy:
-                Not empty
-                os.path.abspath resolves to a child address
-                Path does not contain ('.', '..', '', '/')
-            Note: os.path.abspath is used instead of os.path.realpath to prevent
-             symbolic link issues, because the file is not on server
-            Note: os.path.abspath is not 100% safe
-            Note: currently only using Linux pathname conventions
-        '''
+        """
+        Return whether a pathname (for file, in director tree) is safe
+        Current policy:
+            Not empty
+            os.path.abspath resolves to a child address
+            Path does not contain ('.', '..', '', '/')
+        Note: os.path.abspath is used instead of os.path.realpath to prevent
+         symbolic link issues, because the file is not on server
+        Note: os.path.abspath is not 100% safe
+        Note: currently only using Linux pathname conventions
+        """
         if not pathname:
             return False
         path = pathname
@@ -133,11 +133,11 @@ class MyHelpers:
         return ans
 
     def json_files_unpack(self, json_str, target):
-        '''
-            Generate a list of File objects from a JSON directory tree
-            json_str: json object as string; raise error when None
-            target: a list to put file objects in
-        '''
+        """
+        Generate a list of File objects from a JSON directory tree
+        json_str: json object as string; raise error when None
+        target: a list to put file objects in
+        """
         if json_str is None:
             self.json_error(400, 'Please supply files')
         try:
@@ -409,10 +409,10 @@ class ListCourses(MyRequestHandler):
 
     @authenticated
     def get(self):
-        '''
-            List all available courses the user is taking or teaching. (anyone)
-            List all courses in ngshare. (admin)
-        '''
+        """
+        List all available courses the user is taking or teaching. (anyone)
+        List all courses in ngshare. (admin)
+        """
         courses = set()
         if self.is_admin():
             for i in self.db.query(Course).all():
@@ -460,10 +460,10 @@ class ManageInstructor(MyRequestHandler):
 
     @authenticated
     def post(self, course_id, instructor_id):
-        '''
-            Add or update a course instructor. (admin)
-            Update self full name or email. (instructors)
-        '''
+        """
+        Add or update a course instructor. (admin)
+        Update self full name or email. (instructors)
+        """
         course = self.find_course(course_id)
         self.check_course_instructor(course)
         instructor = self.find_or_create_user(instructor_id)
@@ -564,10 +564,10 @@ class ManageStudent(MyRequestHandler):
 
     @authenticated
     def get(self, course_id, student_id):
-        '''
-            Get information about a student.
-            (instructors+student with same student_id)
-        '''
+        """
+        Get information about a student.
+        (instructors+student with same student_id)
+        """
         course = self.find_course(course_id)
         if self.user.id != student_id:
             self.check_course_instructor(course)
@@ -635,7 +635,10 @@ class ListStudents(MyRequestHandler):
             association.last_name = i['last_name']
             association.email = i['email']
             ans.append(
-                {'username': i['username'], 'success': True,}
+                {
+                    'username': i['username'],
+                    'success': True,
+                }
             )
         self.db.commit()
         self.json_success(status=ans)
@@ -705,10 +708,10 @@ class ListSubmissions(MyRequestHandler):
     '/api/submissions/<course_id>/<assignment_id>'
 
     def get(self, course_id, assignment_id):
-        '''
-            List all submissions for an assignment from all students
-             (instructors only)
-        '''
+        """
+        List all submissions for an assignment from all students
+         (instructors only)
+        """
         course = self.find_course(course_id)
         self.check_course_instructor(course)
         assignment = self.find_assignment(course, assignment_id)
@@ -727,11 +730,11 @@ class ListStudentSubmissions(MyRequestHandler):
     '/api/submissions/<course_id>/<assignment_id>/<student_id>'
 
     def get(self, course_id, assignment_id, student_id):
-        '''
-            List all submissions for an assignment from a particular student
-             (instructors+students,
-              students restricted to their own submissions)
-        '''
+        """
+        List all submissions for an assignment from a particular student
+         (instructors+students,
+          students restricted to their own submissions)
+        """
         course = self.find_course(course_id)
         if self.user.id != student_id:
             self.check_course_instructor(course)
@@ -767,10 +770,10 @@ class DownloadAssignment(MyRequestHandler):
     '/api/submission/<course_id>/<assignment_id>/<student_id>'
 
     def get(self, course_id, assignment_id, student_id):
-        '''
-            Download a student's submitted assignment (instructors only)
-            TODO: maybe allow student to see their own submissions?
-        '''
+        """
+        Download a student's submitted assignment (instructors only)
+        TODO: maybe allow student to see their own submissions?
+        """
         course = self.find_course(course_id)
         self.check_course_instructor(course)
         assignment = self.find_assignment(course, assignment_id)
@@ -795,10 +798,10 @@ class UploadDownloadFeedback(MyRequestHandler):
     '/api/feedback/<course_id>/<assignment_id>/<student_id>'
 
     def post(self, course_id, assignment_id, student_id):
-        '''
-            POST /api/feedback/<course_id>/<assignment_id>/<student_id>
-            Upload feedback on a student's assignment (instructors only)
-        '''
+        """
+        POST /api/feedback/<course_id>/<assignment_id>/<student_id>
+        Upload feedback on a student's assignment (instructors only)
+        """
         course = self.find_course(course_id)
         self.check_course_instructor(course)
         assignment = self.find_assignment(course, assignment_id)
@@ -819,11 +822,11 @@ class UploadDownloadFeedback(MyRequestHandler):
         self.json_success()
 
     def get(self, course_id, assignment_id, student_id):
-        '''
-            GET /api/feedback/<course_id>/<assignment_id>/<student_id>
-            Download feedback on a student's assignment
-             (instructors+students, students restricted to own submissions)
-        '''
+        """
+        GET /api/feedback/<course_id>/<assignment_id>/<student_id>
+        Download feedback on a student's assignment
+         (instructors+students, students restricted to own submissions)
+        """
         course = self.find_course(course_id)
         if self.user.id != student_id:
             self.check_course_instructor(course)
@@ -871,7 +874,11 @@ class InitDatabase(MyRequestHandler):
                 for line in value:
                     tbody.append(list(map(line.__getitem__, thead)))
                 ans.append(
-                    {'header': key, 'thead': thead, 'tbody': tbody,}
+                    {
+                        'header': key,
+                        'thead': thead,
+                        'tbody': tbody,
+                    }
                 )
             self.render('dump.html', tables=ans)
         else:
@@ -954,9 +961,9 @@ class MyApplication(Application):
 
 
 class MockAuth(HubAuthenticated):
-    '''
-        Mock class substituting HubAuthenticated, for vngshare
-    '''
+    """
+    Mock class substituting HubAuthenticated, for vngshare
+    """
 
     def get_login_url(self):
         return 'http://example.com/'


### PR DESCRIPTION
Apparently you aren't supposed to specify a subfolder as the name field in chartpress.yaml. This causes chartpress to fail (not sure why an older version of chartpress doesn't have this issue):
```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.8.7/bin/chartpress", line 8, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.8.7/lib/python3.8/site-packages/chartpress.py", line 885, in main
    publish_pages(
  File "/home/travis/virtualenv/python3.8.7/lib/python3.8/site-packages/chartpress.py", line 683, in publish_pages
    if any(c["version"] == chart_version for c in published_charts):
TypeError: 'NoneType' object is not iterable
```

This PR moves chartpress.yaml into the helmchart directory and tells travis to run chartpress in there instead.

Closes #140 (even though it doesn't explain the weird helm checksum error, nor why it takes 3 million years to start running a job).