### PR TITLE
Fix Sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt
+


### PR DESCRIPTION
After !149 is checked in, I realized that building the docs on readthedocs.org fails: https://readthedocs.org/projects/ngshare/builds/18025387/
```
 /home/docs/checkouts/readthedocs.org/user_builds/ngshare/envs/latest/bin/python -m sphinx -b latex -D language=en -d _build/doctrees . _build/latex
Running Sphinx v1.8.6
loading translations [en]... done
making output directory...
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [latex]: all documents
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
processing ngshare.tex...index user_guide/install user_guide/install_z2jh user_guide/install_jupyterhub user_guide/install_unmanaged user_guide/uninstall user_guide/upgrade user_guide/cmdline user_guide/extra user_guide/notes_admin user_guide/notes_instructor user_guide/course_management user_guide/bugs user_guide/change_log api/index api/definition api/req_res api/authentication api/course api/assignment contributer_guide/why_ngshare contributer_guide/system_architecture contributer_guide/project_structure contributer_guide/decisions contributer_guide/install contributer_guide/vngshare contributer_guide/development contributer_guide/database contributer_guide/alembic contributer_guide/docs contributer_guide/deploy 
resolving references...
/home/docs/checkouts/readthedocs.org/user_builds/ngshare/envs/latest/lib/python3.7/site-packages/sphinx/builders/latex/__init__.py:201: FutureWarning: 
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  if toctrees[0].get('maxdepth') > 0:
/home/docs/checkouts/readthedocs.org/user_builds/ngshare/checkouts/latest/docs/index.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://img.shields.io/badge/code%20style-black-000000.svg)
/home/docs/checkouts/readthedocs.org/user_builds/ngshare/checkouts/latest/docs/index.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://travis-ci.org/LibreTexts/ngshare.svg?branch=master)
/home/docs/checkouts/readthedocs.org/user_builds/ngshare/checkouts/latest/docs/index.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://codecov.io/gh/LibreTexts/ngshare/branch/master/graph/badge.svg)
/home/docs/checkouts/readthedocs.org/user_builds/ngshare/checkouts/latest/docs/index.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://readthedocs.org/projects/ngshare/badge/?version=latest)
writing... 
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/ngshare/envs/latest/lib/python3.7/site-packages/sphinxcontrib/tikz.py", line 392, in latex_visit_tikz
    if self.no_latex_floats:
AttributeError: 'LaTeXTranslator' object has no attribute 'no_latex_floats'
The full traceback has been saved in /tmp/sphinx-err-qnzj7d9y.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks! 
```
I am not sure why it happens and how to fix it, but I tried adding `.readthedocs.yaml` and specifying Python 3.10 and it works.
Preview this build: https://ngshare.readthedocs.io/en/lxy-tmp/api/course.html
Build logs: https://readthedocs.org/projects/ngshare/builds/18025440/