### PR TITLE
Update Docs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/docs/api/authentication.rst
+++ b/docs/api/authentication.rst
@@ -6,6 +6,8 @@ ngshare Authentication
 
 ``ngshare`` uses JupyterHub authentication tokens to authenticate the user. This is usually in the ``JUPYTERHUB_API_TOKEN`` environment variable in each user's notebook servers. ``ngshare`` will use this token to fetch the username of the current user. The username is the only information used to identify the user.
 
+When accessing JupyterHub's `services/ngshare` webpage, the authentication token is exchanged through secure cookies. If the cookie is not set, the user is sent through the JupyterHub OAuth process.
+
 To send the token to ``ngshare``, use the ``Authorization: token`` header in HTTP requests to ``ngshare``.
 
 GET Example

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ project = 'ngshare'
 copyright = '2020, Team KALE'
 author = 'Team KALE'
 
+
 # The full version, including alpha/beta/rc tags
 def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))

--- a/docs/user_guide/install_jupyterhub.rst
+++ b/docs/user_guide/install_jupyterhub.rst
@@ -33,14 +33,11 @@ After you restart JupyterHub, you can verify the service is working as intended 
 Installing ngshare_exchange
 ---------------------------
 
-``ngshare_exchange`` can be installed like any other python package. Be sure to install and enable the ``nbgrader`` extension as well:
+``ngshare_exchange`` can be installed like any other python package:
 
 .. code:: bash
 
     python3 -m pip install ngshare_exchange
-    jupyter nbextension install --symlink --sys-prefix --py nbgrader
-    jupyter nbextension enable --sys-prefix --py nbgrader
-    jupyter serverextension enable --sys-prefix --py nbgrader
 
 Finally, you need to configure nbgrader to use ngshare_exchange. This can be done by adding the following to nbgrader's global config file, ``/etc/jupyter/nbgrader_config.py``:
 

--- a/docs/user_guide/install_z2jh.rst
+++ b/docs/user_guide/install_z2jh.rst
@@ -108,14 +108,11 @@ Installing ngshare_exchange
 
 You should know how to `customize the user environment using Dockerfiles <https://zero-to-jupyterhub.readthedocs.io/en/latest/customizing/user-environment.html>`_ in Z2JH. For the clients to use ``ngshare``, the exchange must be installed in every user pod.
 
-``ngshare_exchange`` can be installed like any other python package. Be sure to install and enable the ``nbgrader`` extension as well:
+``ngshare_exchange`` can be installed like any other python package:
 
 .. code:: bash
 
     python3 -m pip install ngshare_exchange
-    jupyter nbextension install --symlink --sys-prefix --py nbgrader
-    jupyter nbextension enable --sys-prefix --py nbgrader
-    jupyter serverextension enable --sys-prefix --py nbgrader
 
 Finally, you need to configure nbgrader to use ngshare_exchange. This can be done by adding some code to nbgrader's global config file, ``/etc/jupyter/nbgrader_config.py``. The relevant code should be output by the ``helm install`` command earlier when you installed ``ngshare``:
 

--- a/docs/user_guide/install_z2jh.rst
+++ b/docs/user_guide/install_z2jh.rst
@@ -101,7 +101,8 @@ In addition, it is also necessary to append the following configuration values t
       egressAllowRules:
         privateIPs: true
 
-After you have updated Z2JH's configuration using ``helm upgrade``, you can verify the service is working as intended by logging into JupyterHub, clicking "Control Panel", then "Services -> ngshare". If you see the ``ngshare`` welcome page, you may proceed.
+After you have updated Z2JH's configuration using ``helm upgrade``, you can verify the service is working as intended by logging into JupyterHub, clicking "Control Panel", then "Services -> ngshare". 
+If you see the ``ngshare`` welcome page, you may proceed. If you get a 403 Forbidden error, try visiting the page as an admin.
 
 Installing ngshare_exchange
 ---------------------------

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: POSIX :: Linux",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'SQLAlchemy>=1.3.12',
         'alembic>=1.3.2',

--- a/testing/docker/entrypoint.sh
+++ b/testing/docker/entrypoint.sh
@@ -6,10 +6,6 @@ cd /srv/src/nbgrader
 
 pip install -e .
 
-jupyter nbextension install --symlink --sys-prefix --py nbgrader
-jupyter nbextension enable --sys-prefix --py nbgrader
-jupyter serverextension enable --sys-prefix --py nbgrader
-
 # Then start jupyterhub
 
 cd -

--- a/testing/install_jhmanaged/Dockerfile
+++ b/testing/install_jhmanaged/Dockerfile
@@ -12,12 +12,6 @@ RUN python3 -m pip install ngshare
 # Configure JupyterHub to spawn ngshare
 COPY jupyterhub_config.py .
 
-# Install nbgrader
-RUN python3 -m pip install git+https://github.com/jupyter/nbgrader.git@5a81fd5 && \
-    jupyter nbextension install --symlink --sys-prefix --py nbgrader && \
-    jupyter nbextension enable --sys-prefix --py nbgrader && \
-    jupyter serverextension enable --sys-prefix --py nbgrader
-
 # Install ngshare_exchange
 RUN python3 -m pip install ngshare_exchange
 

--- a/testing/install_z2jh/Dockerfile-singleuser
+++ b/testing/install_z2jh/Dockerfile-singleuser
@@ -1,14 +1,7 @@
-FROM jupyterhub/k8s-singleuser-sample:0.9.0
-
-# Install nbgrader and enable the extensions
-# The current master branch (commit 5a81fd5) has been tested to work
-RUN python3 -m pip install git+https://github.com/jupyter/nbgrader.git@5a81fd5 && \
-    jupyter nbextension install --symlink --sys-prefix --py nbgrader && \
-    jupyter nbextension enable --sys-prefix --py nbgrader && \
-    jupyter serverextension enable --sys-prefix --py nbgrader
+FROM jupyter/minimal-notebook:hub-3.0.0
 
 # Install ngshare_exchange
-RUN python3 -m pip install ngshare_exchange
+RUN python3 -m pip install ngshare_exchange --no-cache-dir
 
 # Configure nbgrader
 COPY nbgrader_config.py /etc/jupyter/nbgrader_config.py

--- a/testing/install_z2jh/config_z2jh.yaml
+++ b/testing/install_z2jh/config_z2jh.yaml
@@ -8,7 +8,8 @@ hub:
       c.JupyterHub.services.append({
         'name': 'ngshare',
         'url': 'http://ngshare:8080',
-        'api_token': 'demo_token_9wRp0h4BLzAnC88jjBfpH0fa4QV9tZNI'})
+        'api_token': 'demo_token_9wRp0h4BLzAnC88jjBfpH0fa4QV9tZNI',
+        'oauth_no_confirm': True})
 singleuser:
   image:
     name: ngshare-singleuser-sample

--- a/testing/minikube/Dockerfile-singleuser
+++ b/testing/minikube/Dockerfile-singleuser
@@ -3,8 +3,5 @@ USER 0
 RUN apt update && apt install -y curl nano
 COPY nbgrader_config.py /etc/jupyter/
 USER $NB_UID
-RUN pip install git+https://github.com/LibreTexts/nbgrader@exchange_server && \
-jupyter nbextension install --symlink --sys-prefix --py nbgrader && \
-jupyter nbextension enable --sys-prefix --py nbgrader && \
-jupyter serverextension enable --sys-prefix --py nbgrader
+RUN pip install git+https://github.com/LibreTexts/nbgrader@exchange_server
 RUN mkdir /opt/course_management && cd /opt/course_management && curl -O https://raw.githubusercontent.com/LibreTexts/ngshare/course-management/course_management/README.md -O https://raw.githubusercontent.com/LibreTexts/ngshare/course-management/course_management/ngshare_management.py -O https://raw.githubusercontent.com/LibreTexts/ngshare/course-management/course_management/students.csv


### PR DESCRIPTION
Closes #159 

Removes Python 3.6 support since it breaks CI and 3.6 isn't supported by ngshare_exchange anyway.
